### PR TITLE
Homepage

### DIFF
--- a/app/assets/stylesheets/home.css.scss
+++ b/app/assets/stylesheets/home.css.scss
@@ -254,6 +254,7 @@ h2.circle {
         border-radius: 10px;
         position:relative;
         padding:10px;
+        img{width:620px; border-radius:5px;}
         .slides_accent{
           width:75px;
           height:75px;

--- a/app/views/refinery/pages/home.html.erb
+++ b/app/views/refinery/pages/home.html.erb
@@ -38,20 +38,3 @@
     </div> 
   </div>
 </section>
-
-<section id="row3">
-  <div class="wrap">
-    <div class="row_left">
-      <%=raw @page.content_for(:row_three_left) %>
-    </div>
-    <div class="row_right">
-      <div id="slides">
-        <div id="video">
-          <%=raw @page.content_for(:row_three_right) %>
-        </div>
-      </div>
-    </div> 
-  </div>
-</section>
-
-

--- a/app/views/refinery/pages/home.html.erb
+++ b/app/views/refinery/pages/home.html.erb
@@ -20,7 +20,7 @@
 <section id="row2">
   <div class="wrap">
     <div class="row_left">
-      <%=raw @page.content_for(:row_two_left) %>
+      <%=raw @page.content_for(:side_body) %>
     </div>
     <div class="row_right">
       <div id="slides">


### PR DESCRIPTION
add some style to the home page slideshow.

remove the third row of content from the home page view.

pull the sidebody content into the space left of the slideshow.

We shouldn't merge this unless the problem of the app/views/refinery/pages/home.html.erb file being used for all pages is solved.  If that isn't gonna be fixed, then I can get rid of the last couple commits on this and go a different route on a few of the things.
